### PR TITLE
update requirements to allow Laravel 10

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,6 @@
     ],
     "require": {
         "php": "^8.1",
-        "illuminate/contracts": "^9.0",
         "spatie/laravel-package-tools": "^1.9.2",
         "twilio/sdk": "^6.40"
     },

--- a/src/Channels/TwilioChannel.php
+++ b/src/Channels/TwilioChannel.php
@@ -3,7 +3,6 @@
 namespace Clevyr\LaravelTwilioChannel\Channels;
 
 use Clevyr\LaravelTwilioChannel\Contracts\TwilioNotification;
-use Illuminate\Notifications\Notification;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Log;
 use Twilio\Rest\Client;
@@ -49,7 +48,6 @@ class TwilioChannel
      * Send the given notification.
      *
      * @param  mixed  $notifiable
-     * @param  \Clevyr\LaravelTwilioChannel\Contracts\TwilioNotification  $notification
      * @return void
      */
     public function send($notifiable, TwilioNotification $notification)

--- a/src/Messages/TwilioMessage.php
+++ b/src/Messages/TwilioMessage.php
@@ -14,7 +14,6 @@ class TwilioMessage
     /**
      * Append an entry into the messages array.
      *
-     * @param  string  $text
      * @return \Clevyr\LaravelTwilioChannel\Messages\TwilioMessage
      */
     public function line(string $text)


### PR DESCRIPTION
- Update composer requirements to allow for Laravel 10 installations
- `illuminate/contracts` is no longer a package installed with Laravel 10 as it's baked into the framework